### PR TITLE
Remove unused localhost:1600 from allowedOrigins

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const app = express();
 app.use(express.urlencoded({ extended: true }))
 app.use(express.json());
 
-const allowedOrigins = process.env.NODE_ENV === "production" ? ["https://infinitypymes.com", "https://infinity-pymes-front.vercel.app"] : ["http://localhost:1600", "http://localhost:5173", "http://localhost:5174"]
+const allowedOrigins = process.env.NODE_ENV === "production" ? ["https://infinitypymes.com", "https://infinity-pymes-front.vercel.app"] : ["http://localhost:5173", "http://localhost:5174"]
 
 const corsOptions = {
     origin: function (origin, callback) {


### PR DESCRIPTION
The development CORS allowedOrigins list no longer includes http://localhost:1600, likely because it is not needed for local development. This helps tighten CORS policy and avoid unnecessary exposure.